### PR TITLE
Adds NPM Registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@apollosproject/upgrade-tools",
+  "registry": "https://registry.npmjs.org/",
   "version": "0.3.2",
   "description": "",
   "main": "src/index.js",


### PR DESCRIPTION
It said `error Couldn't publish package: "https://registry.yarnpkg.com/@apollosproject%2fupgrade-tools: Not found"`  so not sure how you did it before but I guess we should specify registry here?
